### PR TITLE
Fix session retrieval bug

### DIFF
--- a/session.py
+++ b/session.py
@@ -377,7 +377,7 @@ class SessionManager:
             raw = await self.redis.get(key)
             if raw:
                 sa = SessionAPIKey.from_json(raw)
-                sessions[s.id] = sa
+                sessions[sa.id] = sa
 
         return sessions
 


### PR DESCRIPTION
## Summary
- fix bug in session manager when listing API key sessions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684033fe675083229331761c2630ebc3